### PR TITLE
Resolve warnings of no reachability and MIME type detection

### DIFF
--- a/SMReactiveRestKit.podspec
+++ b/SMReactiveRestKit.podspec
@@ -14,6 +14,18 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   s.ios.frameworks = 'SystemConfiguration', 'MobileCoreServices'
+  s.osx.frameworks = 'SystemConfiguration', 'CoreServices'
+  s.prefix_header_contents = <<-EOS
+#import <Availability.h>
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+  #import <SystemConfiguration/SystemConfiguration.h>
+  #import <MobileCoreServices/MobileCoreServices.h>
+#else
+  #import <SystemConfiguration/SystemConfiguration.h>
+  #import <CoreServices/CoreServices.h>
+#endif
+EOS
+
   s.requires_arc = true
   s.source_files = 'Classes'
   s.public_header_files = 'Classes/*.h'


### PR DESCRIPTION
Because you extend RestKit and thus import it in the header, which is importing AFNetworking, which reports that these frameworks should be linked with. And also added these frameworks in the precompiled header because it's the way AFNetworking waiting for it.
